### PR TITLE
modify(#14) : 인벤토리 아이템 데이터 jotai 대신 useState 사용

### DIFF
--- a/src/components/my-page/contents/inventory/InventoryItemBox.tsx
+++ b/src/components/my-page/contents/inventory/InventoryItemBox.tsx
@@ -2,7 +2,7 @@
 
 import * as S from '@/components/my-page/contents/inventory/style';
 import { useAtom } from 'jotai';
-import { themeAtom, userItemAtom } from '@/states/itemAtoms';
+import { themeAtom } from '@/states/itemAtoms';
 import { useEffect, useState } from 'react';
 import INVENTORY from '@/app/api/inventory';
 
@@ -18,7 +18,7 @@ interface Item {
 export default function InventoryItemBox() {
   const [status, setStatus] = useState(true);
   const [theme] = useAtom<string>(themeAtom);
-  const [userItem, setUserItem] = useAtom(userItemAtom);
+  const [userItem, setUserItem] = useState([]);
 
   const getInventoryItem = async () => {
     const response = await INVENTORY.getInventoryItem(1, theme);

--- a/src/states/itemAtoms.ts
+++ b/src/states/itemAtoms.ts
@@ -1,4 +1,3 @@
 import { atom } from 'jotai';
 
-export const userItemAtom = atom([]);
 export const themeAtom = atom('봄 테마');


### PR DESCRIPTION
<!-- 내용 (필수) -->

### Description

- 인벤토리 아이템 데이터 같은 경우, props 로 내려가거나 올라가는 부분이 없어서 jotai 를 사용할 이유가 없다고 판단하였습니다.
- useState 만 이용해서 가져오는 로직으로 변경 하였습니다.
- https://velog.io/@woohm402/no-global-state-manager <-- 해당 글을 읽고 내린 판단 입니다.

<!-- 추가예정 내용 (있다면 필수)-->

### Schedule

-

<!-- 추가된 전역관리 내용 (있다면 필수) -->

### Global Style, Recoil, Hook(선택)

<!-- S3에 업로드 시 작성 (있다면 필수) -->

### S3 추가 내용(선택)

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer(선택)

<!-- 참고한 레퍼런스 링크 (선택) -->

### Reference Link(선택)

<!-- 관련된 이슈 링크 (선택) -->

### Related Issue Link(선택)
