### PR TITLE
우편함 페이지에서 답장&다시 보내기 모달창 구현하였습니다

### DIFF
--- a/my-loader.ts
+++ b/my-loader.ts
@@ -1,0 +1,3 @@
+function myLoader({ src, width, quality }) {
+  return `https://wang0514.s3.ap-northeast-2.amazonaws.com/page/${src}?w=${width}&q=${quality || 75}`;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -3,14 +3,8 @@ module.exports = {
     styledComponents: true,
   },
   images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'wang0514.s3.ap-northeast-2.amazonaws.com',
-        port: '',
-        pathname: '/toonda-image/**',
-      },
-    ],
+    loader: 'custom',
+    loaderFile: './my-loader.ts',
   },
 };
 

--- a/src/app/api/neighbor.ts
+++ b/src/app/api/neighbor.ts
@@ -6,7 +6,6 @@ const NEIGHBOR = {
 
   /** 친구 요청 보내기 API */
   async sendFriendRequest(userNo: number): Promise<any> {
-<<<<<<< HEAD
     if (!window.confirm('이웃 요청을 보내시겠습니까?')) {
       return; // 확인을 받지 못하면 함수 종료
     }
@@ -26,12 +25,6 @@ const NEIGHBOR = {
         }
       }
     }
-=======
-    const result: AxiosResponse = await instance.post(
-      `/users/${userNo}${NEIGHBOR.path}`,
-    );
-    return result.data;
->>>>>>> 35c1b13107e50a6c0865d5a38980d30145b6c68e
   },
 
   /** 이웃 목록 불러오기 API */

--- a/src/app/my-page/mailbox/page.tsx
+++ b/src/app/my-page/mailbox/page.tsx
@@ -1,8 +1,15 @@
-import MailBox from "@/components/my-page/contents/mail-box/MailBox";
+'use client';
+
+import MailBox from '@/components/my-page/contents/mail-box/MailBox';
+import SendPostModal from '@/components/my-page/send-post-modal/SendPostModal';
+import { isSendMailModalAtom } from '@/states/mailboxAtoms';
+import { useAtomValue } from 'jotai';
 
 export default function MyPage() {
+  const isModal = useAtomValue(isSendMailModalAtom);
   return (
     <>
+      {isModal ? <SendPostModal /> : <></>}
       <MailBox />
     </>
   );

--- a/src/app/my-page/neighbor/page.tsx
+++ b/src/app/my-page/neighbor/page.tsx
@@ -1,9 +1,16 @@
+'use client';
+
 import Neighbor from '@/components/my-page/contents/neighbor/Neighbor';
+import SendPostModal from '@/components/my-page/send-post-modal/SendPostModal';
+import { isNeighborSendModalAtom } from '@/states/neighbor';
+import { useAtomValue } from 'jotai';
 
 export default function Page() {
+  const isSendMailModal = useAtomValue(isNeighborSendModalAtom);
   return (
     <>
-      <Neighbor></Neighbor>
+      {isSendMailModal === true ? <SendPostModal /> : <></>}
+      <Neighbor />
     </>
   );
 }

--- a/src/components/my-page/contents/mail-box/PostInfo.tsx
+++ b/src/components/my-page/contents/mail-box/PostInfo.tsx
@@ -5,9 +5,11 @@ import {
   senderDataAtom,
   viewSendPageAtom,
   viewReceiverPageAtom,
+  isSendMailModalAtom,
+  sendMailDataAtom,
 } from '@/states/mailboxAtoms';
-import { useAtomValue } from 'jotai';
-import { useEffect, useRef, useState } from 'react';
+import { useAtom, useAtomValue } from 'jotai';
+import { useEffect, useState } from 'react';
 
 export default function PostInfo(props: { title: string }) {
   const page = useAtomValue(
@@ -17,9 +19,8 @@ export default function PostInfo(props: { title: string }) {
   const receiverData = useAtomValue(receiverDataAtom);
   const [sendPostNo, setSendPostNo] = useState(senderData[page]?.no);
   const [receivePostNo, setReceivePostNo] = useState(receiverData[page]?.no);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [reply, setReply] = useState<string | null>(null);
-  const [postUi, setPostUi] = useState(true);
+  const [isSendMailModal, setIsSendMailModal] = useAtom(isSendMailModalAtom);
+  const [sendMailData, setSendMailData] = useAtom(sendMailDataAtom);
 
   const handleClickDelete = () => {
     const postNo = props.title.includes('보낸') ? sendPostNo : receivePostNo;
@@ -28,21 +29,19 @@ export default function PostInfo(props: { title: string }) {
     }
   };
 
-  const sendPost = async () => {
-    setReply(null);
-    setPostUi(true);
-    createPost();
+  const handleClickModal = () => {
+    setIsSendMailModal(true);
+    if (props.title.includes('받은 편지')) {
+      setSendMailData(receiverData[page].userPostSenderNo);
+    } else if (props.title.includes('보낸 편지')) {
+      setSendMailData(senderData[page].userPostReceiverNo);
+    }
   };
 
   const setPostCheck = async (no: number) => {
     if (no) {
       await MAILBOX.setPostCheck(no);
     }
-  };
-
-  const onClickHandle = () => {
-    setPostUi(false);
-    setReply('답장을 보내보세요!');
   };
 
   useEffect(() => {
@@ -53,28 +52,16 @@ export default function PostInfo(props: { title: string }) {
       setReceivePostNo(receiverData[page]?.no);
       setPostCheck(receivePostNo);
     }
-  }, [props.title, page, senderData, receiverData]);
-
-  const createPost = async () => {
-    const content = textareaRef.current?.value || '';
-    await MAILBOX.createPost(receiverData[page].userPostSenderNo.no, content);
-  };
+  }, [props.title, page, senderData, receiverData, isSendMailModal]);
 
   return (
     <>
       <S.ContentsView height="25vh">
         <S.ListScroll>
           <S.MarginDiv $fontSize="18px" $margin="3vh 2vw" $textAlign="left">
-            {props.title.includes('보낸') ? (
-              senderData[page]?.content
-            ) : (
-              <div onClick={onClickHandle}>
-                <S.PostTextarea
-                  ref={textareaRef}
-                  defaultValue={receiverData[page]?.content}
-                />
-              </div>
-            )}
+            {props.title.includes('보낸')
+              ? senderData[page]?.content
+              : receiverData[page]?.content}
           </S.MarginDiv>
         </S.ListScroll>
         <S.MarginDiv
@@ -84,27 +71,26 @@ export default function PostInfo(props: { title: string }) {
           color="#767676">
           {props.title.includes('보낸')
             ? senderData[page]?.createdAt
-            : reply
-              ? reply
-              : receiverData[page]?.createdAt}
+            : receiverData[page]?.createdAt}
         </S.MarginDiv>
         <hr style={{ width: '90%', borderTop: '1px dashed' }} />
         <S.MarginDiv $margin="-1vh 2vw 0 0" $textAlign="right">
-          {postUi ? (
+          <S.ReceiverMailFooter>
+            <S.MarginDiv
+              onClick={() => handleClickModal()}
+              $fontSize="18px"
+              $margin="0 0 0.2vw 2.5vw"
+              color="#3A3EA0"
+              cursor="pointer">
+              {props.title.includes('받은 편지') ? '답장하기' : '다시 보내기'}
+            </S.MarginDiv>
             <S.Image
               src="https://wang0514.s3.ap-northeast-2.amazonaws.com/page/trash.png"
               alt="del"
               width="33vw"
               onClick={handleClickDelete}
             />
-          ) : (
-            <S.Image
-              src="https://wang0514.s3.ap-northeast-2.amazonaws.com/page/free-icon-edit-button-7734280.png"
-              alt="post"
-              width="33vw"
-              onClick={sendPost}
-            />
-          )}
+          </S.ReceiverMailFooter>
         </S.MarginDiv>
       </S.ContentsView>
     </>

--- a/src/components/my-page/contents/mail-box/style.ts
+++ b/src/components/my-page/contents/mail-box/style.ts
@@ -52,6 +52,7 @@ export const MarginDiv = styled.div<StyleType>`
   font-size: ${(props) => props.$fontSize};
   color: ${(props) => props.color};
   text-align: ${(props) => props.$textAlign};
+  cursor: ${(props) => props.cursor};
 `;
 
 /** ItemInfo 에 있는 삭제 버튼 담는 섹션 */
@@ -67,7 +68,7 @@ export const ItemImg = styled.div`
   margin-top: -3.5vh;
 `;
 
-/** font size 설정하는 div */
+/** font 설정하는 div */
 export const FontSize = styled.div<StyleType>`
   font-size: ${(props) => props.$fontSize};
   margin: 1px;
@@ -134,4 +135,12 @@ export const AcceptRejectUi = styled.div`
   &:hover {
     cursor: pointer;
   }
+`;
+
+/** 받은 편지일 때 답장하기, 휴지통 담는 Div */
+export const ReceiverMailFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.2vw;
 `;

--- a/src/components/my-page/contents/neighbor/UserListItem.tsx
+++ b/src/components/my-page/contents/neighbor/UserListItem.tsx
@@ -1,10 +1,24 @@
+'use client';
+
 import * as S from './style';
-import { useAtomValue } from 'jotai';
-import { pageViewTypeAtom } from '@/states/neighbor';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { isNeighborSendModalAtom, pageViewTypeAtom } from '@/states/neighbor';
 import NEIGHBOR from '@/app/api/neighbor';
+import { sendMailDataAtom } from '@/states/mailboxAtoms';
 
 export default function UserListItem(props: any) {
+  const setIsSendMailModal = useSetAtom(isNeighborSendModalAtom);
+  const [sendMailModalData, setSendMailModalData] = useAtom(sendMailDataAtom);
   const pageViewType = useAtomValue(pageViewTypeAtom);
+
+  const handleModal = () => {
+    setIsSendMailModal(true);
+    setSendMailModalData({
+      no: props.userData.neighbor.no,
+      nickname: props.userData.neighbor.nickname,
+    });
+    console.log(sendMailModalData);
+  };
 
   const acceptNeighborRequest = () => {
     NEIGHBOR.acceptNeighborRequest(props.userData.no);
@@ -45,7 +59,7 @@ export default function UserListItem(props: any) {
       <S.ColumnSection>
         {pageViewType === 'list' ? (
           <>
-            <S.Button>편지 보내기</S.Button>
+            <S.Button onClick={handleModal}>편지 보내기</S.Button>
             <S.Button>방 보러가기</S.Button>
           </>
         ) : (

--- a/src/components/my-page/contents/neighbor/UserListItem.tsx
+++ b/src/components/my-page/contents/neighbor/UserListItem.tsx
@@ -17,7 +17,6 @@ export default function UserListItem(props: any) {
       no: props.userData.neighbor.no,
       nickname: props.userData.neighbor.nickname,
     });
-    console.log(sendMailModalData);
   };
 
   const acceptNeighborRequest = () => {

--- a/src/components/my-page/send-post-modal/SendPostModal.tsx
+++ b/src/components/my-page/send-post-modal/SendPostModal.tsx
@@ -5,9 +5,11 @@ import * as S from './style';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useEffect, useState } from 'react';
 import MAILBOX from '@/app/api/mailBox';
+import { isNeighborSendModalAtom } from '@/states/neighbor';
 
 export default function SendPostModal() {
   const setIsSendMailModal = useSetAtom(isSendMailModalAtom);
+  const setIsNeighborSendMailModal = useSetAtom(isNeighborSendModalAtom);
   const sendMailData = useAtomValue(sendMailDataAtom);
   const [contents, setContents] = useState('');
 
@@ -15,8 +17,11 @@ export default function SendPostModal() {
     setContents(event.target.value);
   };
 
+  console.log(sendMailData);
+
   const onClickExit = () => {
     setIsSendMailModal(false);
+    setIsNeighborSendMailModal(false);
   };
 
   const sendMail = async () => {

--- a/src/components/my-page/send-post-modal/SendPostModal.tsx
+++ b/src/components/my-page/send-post-modal/SendPostModal.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { isSendMailModalAtom, sendMailDataAtom } from '@/states/mailboxAtoms';
+import * as S from './style';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { useEffect, useState } from 'react';
+import MAILBOX from '@/app/api/mailBox';
+
+export default function SendPostModal() {
+  const setIsSendMailModal = useSetAtom(isSendMailModalAtom);
+  const sendMailData = useAtomValue(sendMailDataAtom);
+  const [contents, setContents] = useState('');
+
+  const onChangeHandle = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setContents(event.target.value);
+  };
+
+  const onClickExit = () => {
+    setIsSendMailModal(false);
+  };
+
+  const sendMail = async () => {
+    if (sendMailData && contents) {
+      await MAILBOX.createPost(sendMailData?.no, contents);
+    } else {
+      alert('편지 내용을 적어주세요!');
+    }
+    setIsSendMailModal(false);
+  };
+
+  return (
+    <>
+      {sendMailData ? (
+        <S.PageDark>
+          <S.SendPostModalBody>
+            <S.SendPostModalHeader>
+              <S.Img
+                src="https://wang0514.s3.ap-northeast-2.amazonaws.com/page/remove.png"
+                width="1.5vw"
+                $margin="1vw"
+                cursor="pointer"
+                onClick={() => onClickExit()}
+              />
+            </S.SendPostModalHeader>
+            <S.SendPostModalTitle>
+              <S.Img
+                src="https://wang0514.s3.ap-northeast-2.amazonaws.com/page/mail.png"
+                width="1.5vw"
+                $margin="1vw"
+              />
+              <S.Font $fontSize="20px" $margin="0 0.5vw">
+                {sendMailData?.nickname} 님께 보내는 편지
+              </S.Font>
+            </S.SendPostModalTitle>
+            <S.InputContainer
+              placeholder="편지를 남겨주세요!"
+              onChange={onChangeHandle}></S.InputContainer>
+            <S.TextCounterContainer>
+              <S.Font
+                $fontSize="16px"
+                color={contents.length < 100 ? '#3B3B3B' : '#FF5454'}>
+                {contents.length}/100자
+              </S.Font>
+            </S.TextCounterContainer>
+            <S.SendPostModalFooter onClick={sendMail}>
+              <S.Font $fontSize="20px" cursor="pointer" $margin="0 0.5vw">
+                전송하기
+              </S.Font>
+              <S.Img
+                src="https://wang0514.s3.ap-northeast-2.amazonaws.com/page/send.png"
+                width="2vw"
+                cursor="pointer"
+                $margin="0 0.5vw 0 0"
+              />
+            </S.SendPostModalFooter>
+          </S.SendPostModalBody>
+        </S.PageDark>
+      ) : (
+        <></>
+      )}
+    </>
+  );
+}

--- a/src/components/my-page/send-post-modal/SendPostModal.tsx
+++ b/src/components/my-page/send-post-modal/SendPostModal.tsx
@@ -3,7 +3,7 @@
 import { isSendMailModalAtom, sendMailDataAtom } from '@/states/mailboxAtoms';
 import * as S from './style';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import MAILBOX from '@/app/api/mailBox';
 import { isNeighborSendModalAtom } from '@/states/neighbor';
 
@@ -16,8 +16,6 @@ export default function SendPostModal() {
   const onChangeHandle = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setContents(event.target.value);
   };
-
-  console.log(sendMailData);
 
   const onClickExit = () => {
     setIsSendMailModal(false);

--- a/src/components/my-page/send-post-modal/style.ts
+++ b/src/components/my-page/send-post-modal/style.ts
@@ -1,0 +1,96 @@
+'use client';
+import { StyleType } from '@/types/style';
+import styled from 'styled-components';
+
+/** 페이지 전체를 어둡게 하기 */
+export const PageDark = styled.div`
+  width: 68.35%;
+  height: 100%;
+  position: fixed;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 30px;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 100;
+`;
+
+/** 편지 보내기 모달창 바디 */
+export const SendPostModalBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 40vw;
+  height: 50vh;
+  background-color: #fff;
+  border-radius: 30px;
+  box-shadow: 0 6px 6px rgba(0, 0, 0, 0.2);
+`;
+
+/** 편지 보내기 모달창 헤더 */
+export const SendPostModalHeader = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  width: 100%;
+  z-index: 50;
+`;
+
+/** 이미지 태그 */
+export const Img = styled.img<StyleType>`
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
+  margin: ${(props) => props.$margin};
+  cursor: ${(props) => props.cursor};
+`;
+
+/** 편지 보내기 모달 타이틀 */
+export const SendPostModalTitle = styled.div`
+  display: flex;
+  align-items: center;
+  margin: -2.5vw -2vw 0 0;
+  width: 100%;
+`;
+
+/** 메모 입력창 */
+export const InputContainer = styled.textarea`
+  width: 35vw;
+  height: 30vh;
+  font-size: 18px;
+  color: #3b3b3b;
+  padding: 1vw;
+  background-color: #d9d9d9;
+  border: none;
+  resize: none;
+  outline: none;
+`;
+
+/** font 설정 */
+export const Font = styled.div<StyleType>`
+  font-size: ${(props) => props.$fontSize};
+  color: ${(props) => props.color};
+  margin: ${(props) => props.$margin};
+  cursor: ${(props) => props.cursor};
+`;
+
+/** 편지 보내기 모달 푸터 */
+export const SendPostModalFooter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 1vw 1vw 0.6vw 1vw;
+  margin-left: -3vw;
+  width: 100%;
+`;
+
+/** pointer css */
+export const CursorPointer = styled.div`
+  cursor: pointer;
+`;
+
+/** 글자수 container */
+export const TextCounterContainer = styled.div`
+  margin-left: auto;
+  margin-top: -2vw;
+  margin-right: 2.5vw;
+`;

--- a/src/states/mailboxAtoms.ts
+++ b/src/states/mailboxAtoms.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai';
-import { MailBoxDataType } from '@/types/mailBox';
+import { MailBoxDataType, SendMailDataType } from '@/types/mailBox';
 
 export const mailBoxSelectAtom = atom<number>(0);
 export const postSenderDataAtom = atom<MailBoxDataType[]>([]);
@@ -8,6 +8,8 @@ export const presentSenderDataAtom = atom<MailBoxDataType[]>([]);
 export const presentReceiverDataAtom = atom<MailBoxDataType[]>([]);
 export const viewSendPageAtom = atom<number>(0);
 export const viewReceiverPageAtom = atom<number>(0);
+export const isSendMailModalAtom = atom<boolean>(false);
+export const sendMailDataAtom = atom<SendMailDataType | null>(null);
 
 export const senderDataAtom = atom((get) => {
   return get(mailBoxSelectAtom) === 0

--- a/src/states/neighbor.ts
+++ b/src/states/neighbor.ts
@@ -1,5 +1,7 @@
+import { SendMailDataType } from '@/types/mailBox';
 import { atom } from 'jotai';
 
 export const pageViewTypeAtom = atom<'list' | 'management'>('list');
 export const neighborListPageAtom = atom<number>(1);
 export const neighborApplicationPageAtom = atom<number>(1);
+export const isNeighborSendModalAtom = atom(false);

--- a/src/types/mailBox.d.ts
+++ b/src/types/mailBox.d.ts
@@ -34,3 +34,8 @@ export interface MailBoxDataType extends PostDataType, PresentsDataType {
   no: number;
   createdAt: string;
 }
+
+export interface SendMailDataType {
+  no: number;
+  nickname: string;
+}

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -37,11 +37,8 @@ interface Props {
   $hasError: string;
   isSelected: boolean;
   flex: string;
-<<<<<<< HEAD
   cursor: string;
-=======
   $right: string;
->>>>>>> a321924e317fae37259e70a96b83c6b6f922037d
 }
 
 export interface StyleType extends Partial<Props> {}

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -37,6 +37,7 @@ interface Props {
   $hasError: string;
   isSelected: boolean;
   flex: string;
+  cursor: string;
 }
 
 export interface StyleType extends Partial<Props> {}


### PR DESCRIPTION
<!-- 내용 (필수) -->

### Description

- 우편함 페이지에서 답장&다시 보내기 모달창 구현하였습니다

<!-- 추가예정 내용 (있다면 필수)-->

### Schedule

- 이웃 페이지에서도 동일한 모달창으로 편지 보낼 수 있도록 만들겠습니다

<!-- 추가된 전역관리 내용 (있다면 필수) -->

### Global Style, Recoil, Hook(선택)

<!-- S3에 업로드 시 작성 (있다면 필수) -->

### S3 추가 내용(선택)

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer(선택)
- 넥스트 이미지 컴포넌트를 사용하기 위해 myloader 함수를 만들었는데, 무슨 오류가 난 건지 잘못된 건지 안 돼서 img 태그를 사용하였습니다.

<!-- 참고한 레퍼런스 링크 (선택) -->

### Reference Link(선택)

<!-- 관련된 이슈 링크 (선택) -->

### Related Issue Link(선택)
#123