### PR TITLE
feat(#125):업적, 서비스정보페이지이동과  틀 정도만 잡아둔 상태

### DIFF
--- a/src/app/my-page/achievement-settings/page.tsx
+++ b/src/app/my-page/achievement-settings/page.tsx
@@ -1,0 +1,5 @@
+import AchievementSettings from '@/components/my-page/contents/my-page-index/AchievementSettings';
+
+export default function MyPage() {
+  return <AchievementSettings />;
+}

--- a/src/app/my-page/service-info/page.tsx
+++ b/src/app/my-page/service-info/page.tsx
@@ -1,0 +1,5 @@
+import ServiceInfo from '@/components/my-page/contents/my-page-index/ServiceInfo';
+
+export default function MyPage() {
+  return <ServiceInfo />;
+}

--- a/src/components/my-page/contents/my-page-index/AchievementSettings.tsx
+++ b/src/components/my-page/contents/my-page-index/AchievementSettings.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import * as S from './style';
+import { useAtom } from 'jotai';
+import { userDataAtom } from '@/states/userAtoms';
+import { useRouter } from 'next/navigation';
+
+export default function AchievementSettings() {
+  const router = useRouter();
+  const [indexUserInfo, setIndexUserInfo] = useAtom(userDataAtom);
+  return (
+    <>
+      <S.Background>
+        <S.UserInfoSection>
+          <S.UserImageContainer onClick={() => router.push('/my-page')}>
+            <img src={indexUserInfo.image} alt="User Profile" />
+          </S.UserImageContainer>
+        </S.UserInfoSection>
+      </S.Background>
+    </>
+  );
+}

--- a/src/components/my-page/contents/my-page-index/MyPage.tsx
+++ b/src/components/my-page/contents/my-page-index/MyPage.tsx
@@ -14,6 +14,7 @@ export default function MyPageIndex() {
   const [isEditDescription, setIsEditDescription] = useState(false);
   const [editDescriptionText, setEditDescriptionText] = useState('');
   const [indexUserInfo, setIndexUserInfo] = useAtom(userDataAtom);
+  const [isProfileClick, setIsProfileClick] = useState(false);
   const [userLegends, setUserLegends] = useState<UserLegendsType>({
     userNo: 0,
     attendanceCount: 0,
@@ -22,6 +23,10 @@ export default function MyPageIndex() {
     presentCount: 0,
     likeCount: 0,
   });
+
+  const handleProfileClick = () => {
+    setIsProfileClick(!isProfileClick);
+  };
 
   const getUserLegends = async () => {
     const response = await LEGENDS.getUserLegends();
@@ -51,7 +56,21 @@ export default function MyPageIndex() {
     <>
       <S.Background>
         <S.UserInfoSection>
-          <S.UserImage src={indexUserInfo.image}></S.UserImage>
+          <S.UserImageContainer
+            onClick={handleProfileClick}
+            isProfileClick={isProfileClick}>
+            <img src={indexUserInfo.image} alt="User Profile" />
+            {isProfileClick && (
+              <div className="button-container">
+                <div onClick={() => alert('이미지업데이트구현전')}>
+                  이미지 업데이트
+                </div>
+                <div onClick={() => router.push('/my-page/service-info')}>
+                  서비스 정보
+                </div>
+              </div>
+            )}
+          </S.UserImageContainer>
           <S.UserInfoContentSection>
             <S.UserInfoContent
               width="8vw"
@@ -61,6 +80,18 @@ export default function MyPageIndex() {
             </S.UserInfoContent>
             <S.UserInfoContent width="30vw" $backColor="#FFDEDE">
               {indexUserInfo.nickname ? indexUserInfo.nickname : '이름 없음'}
+              <S.Font
+                $fontSize="16px"
+                color="#FF3131"
+                $margin="0 0.5vw"
+                cursor="pointer"
+                onClick={() => router.push('/my-page/achievement-settings')}>
+                (
+                {indexUserInfo.userAchievement[0].achievement.title
+                  ? indexUserInfo.userAchievement[0].achievement.title
+                  : '업적 없음'}
+                )
+              </S.Font>
             </S.UserInfoContent>
           </S.UserInfoContentSection>
           <S.UserInfoContentSection $marginTop="16vh">

--- a/src/components/my-page/contents/my-page-index/ServiceInfo.tsx
+++ b/src/components/my-page/contents/my-page-index/ServiceInfo.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useAtom } from 'jotai';
+import * as S from './style';
+import { userDataAtom } from '@/states/userAtoms';
+import { useRouter } from 'next/navigation';
+
+export default function ServiceInfo() {
+  const router = useRouter();
+  const [indexUserInfo, setIndexUserInfo] = useAtom(userDataAtom);
+
+  return (
+    <>
+      <S.Background>
+        <S.UserInfoSection>
+          <S.UserImageContainer onClick={() => router.push('/my-page')}>
+            <img src={indexUserInfo.image} alt="User Profile" />
+          </S.UserImageContainer>
+          <S.ServiceInfoContainer>
+            <S.UserInfoContent width="40vw" $backColor="#FFDEDE">
+              업적 설명
+              <S.Arrow src="https://wang0514.s3.ap-northeast-2.amazonaws.com/page/DownArrow.svg" />
+            </S.UserInfoContent>
+            <S.UserInfoContent
+              $margin="1vw 0 0 0"
+              width="40vw"
+              $backColor="#D7E7FF">
+              회원 정보
+              <S.Arrow src="https://wang0514.s3.ap-northeast-2.amazonaws.com/page/DownArrow.svg" />
+            </S.UserInfoContent>
+          </S.ServiceInfoContainer>
+        </S.UserInfoSection>
+      </S.Background>
+    </>
+  );
+}

--- a/src/components/my-page/contents/my-page-index/style.ts
+++ b/src/components/my-page/contents/my-page-index/style.ts
@@ -15,15 +15,59 @@ export const Background = styled.div`
   border-radius: 20px;
 `;
 
-/** index page 유저 사진 */
-export const UserImage = styled.img`
+interface UserImageContainerProps {
+  isProfileClick?: boolean;
+}
+
+/** 유저 사진 띄워 주는 콘테이너 */
+export const UserImageContainer = styled.div<UserImageContainerProps>`
+  position: relative;
   width: 9vw;
   height: 9vw;
   margin-top: -45vh;
   border-radius: 50%;
-  object-fit: cover;
   border: 15px solid white;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: ${(props) =>
+      props.isProfileClick
+        ? 'brightness(50%)'
+        : 'brightness(100%)'}; // 클릭 상태에 따른 필터 적용
+  }
+
+  .button-container {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    div {
+      width: 5rem;
+      height: 1rem;
+      background-color: rgba(255, 255, 255, 0.8);
+      border: 3px solid #c8c8c8;
+      border-radius: 5px;
+      padding: 0.3rem;
+      cursor: pointer;
+      font-size: 13px;
+      text-align: center;
+      line-height: 1.5;
+      transition: background-color 0.3s ease;
+
+      &:hover {
+        background-color: rgba(255, 255, 255, 1);
+      }
+    }
+  }
 `;
 
 export const UserInfoContentSection = styled.div<StyleType>`
@@ -38,7 +82,7 @@ export const UserInfoContentSection = styled.div<StyleType>`
 
 export const UserInfoContent = styled.div<StyleType>`
   width: ${(props) => props.width};
-  margin: 0 0.3vw;
+  margin: ${(props) => (props.$margin ? props.$margin : '0 0.3vw')};
   display: flex;
   justify-content: ${(props) =>
     props.$textAlign === 'center' ? 'center' : 'flex-start'};
@@ -121,4 +165,32 @@ export const EditText = styled.span`
   color: #585858;
   padding-right: 0.5vw;
   cursor: pointer;
+`;
+
+/** 설명 나오게 하는 img 태그 */
+export const Arrow = styled.img<StyleType>`
+  width: ${(props) => props.width};
+  margin-left: auto;
+  margin-right: 1vw;
+`;
+
+/** font css */
+export const Font = styled.div<StyleType>`
+  font-size: ${(props) => props.$fontSize};
+  color: ${(props) => props.color};
+  margin: ${(props) => props.$margin};
+  cursor: ${(props) => props.cursor};
+`;
+
+/** 서비스 정보 페이지에 있는 서비스 내용들 들어갈 div */
+export const ServiceInfoContainer = styled.div`
+  width: 45vw;
+  height: 30vh;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  flex-direction: column;
+  margin-bottom: -25vh;
+  padding: 1vw;
+  overflow-y: auto;
 `;

--- a/src/components/my-page/send-post-modal/SendPostModal.tsx
+++ b/src/components/my-page/send-post-modal/SendPostModal.tsx
@@ -29,6 +29,7 @@ export default function SendPostModal() {
       alert('편지 내용을 적어주세요!');
     }
     setIsSendMailModal(false);
+    setIsNeighborSendMailModal(false);
   };
 
   return (


### PR DESCRIPTION
<!-- 내용 (필수) -->

### Description

- 마이페이지 인덱스 변경사항 : 프로필 클릭시 업데이트 가능하도록 UI 만들어두고, 서비스정보 페이지 이동가능하게 했습니다
- 서비스정보페이지, 업적페이지 틀 정도만 만들어두었습니다 기능은 내일 추가하겠습니다!
- 업적페이지는 인덱스 페이지에서 이름 옆에 업적 클릭하면 이동합니다.

<!-- 추가예정 내용 (있다면 필수)-->

### Schedule

-

<!-- 추가된 전역관리 내용 (있다면 필수) -->

### Global Style, Recoil, Hook(선택)

<!-- S3에 업로드 시 작성 (있다면 필수) -->

### S3 추가 내용(선택)

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->

### To Reviewer(선택)

<!-- 참고한 레퍼런스 링크 (선택) -->

### Reference Link(선택)

<!-- 관련된 이슈 링크 (선택) -->

### Related Issue Link(선택)
#125